### PR TITLE
Clean multithread

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/infrastructure/ExecutionUnitType.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/infrastructure/ExecutionUnitType.java
@@ -1,5 +1,5 @@
 package uk.ac.imperial.lsds.seep.infrastructure;
 
 public enum ExecutionUnitType {
-	PHYSICAL_NODE, YARN_CONTAINER, DOCKER_CONTAINER
+	PHYSICAL_NODE, THREAD_NODE, YARN_CONTAINER, DOCKER_CONTAINER
 }

--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/metrics/SeepMetrics.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/metrics/SeepMetrics.java
@@ -22,10 +22,17 @@ public class SeepMetrics extends MetricRegistry {
 	public static void configureMetrics(Config config){
 		// TODO: configure this component
 	}
-	
-	public static void startJMXReporter() {
-		jmxReporter = JmxReporter.forRegistry(REG).build();
-		jmxReporter.start();
+	/*
+	 * Method now synchronised to avoid creating multiple JMX reporters 
+	 * when deployment type is multi-thread
+	 */
+	public static synchronized void startJMXReporter() {
+		
+		//Avoid Redifinig jmxReporter in Multi-Thread deployment
+		if(jmxReporter == null){
+			jmxReporter = JmxReporter.forRegistry(REG).build();
+			jmxReporter.start();
+		}
 	}
 	
 	public static void startConsoleReporter(int period) {

--- a/seep-master/build.gradle
+++ b/seep-master/build.gradle
@@ -6,6 +6,7 @@ applicationDefaultJvmArgs = []
 // All dependencies
 dependencies {
 	compile project(':seep-common')
+	compile project(':seep-worker')
 	compile 'org.apache.commons:commons-collections4:4.0'
 	compile 'org.eclipse.jetty:jetty-server:9.2.9.v20150224'
 	compile 'org.eclipse.jetty:jetty-servlet:9.2.9.v20150224'

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/MasterConfig.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/MasterConfig.java
@@ -21,7 +21,7 @@ public class MasterConfig extends Config {
 	
 	public static final String DEPLOYMENT_TARGET_TYPE = "deployment_target.type";
     private static final String DEPLOYMENT_TARGET_TYPE_DOC = "The target cluster to which the master will submit queries."
-    													+ "Physical cluster(0), yarn container(1), lxc, docker, etc";
+    		   													+ "Physical cluster(0), yarn container(1), local multi-thread(2), lxc, docker, etc";
     public static final String LISTENING_PORT = "master.port";
     private static final String LISTENING_PORT_DOC = "The port in which master will receive commands from workers";
     

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/InfrastructureManagerFactory.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/InfrastructureManagerFactory.java
@@ -7,12 +7,18 @@ public class InfrastructureManagerFactory {
 		if(infType == InfrastructureType.PHYSICAL_CLUSTER.ofType()) {
 			name = InfrastructureType.PHYSICAL_CLUSTER.name();
 		}
+		else if(infType == InfrastructureType.LOCAL_MULTITHREAD.ofType()){
+			name = InfrastructureType.LOCAL_MULTITHREAD.name();
+		}
 		return name;
 	}
 	
 	public static InfrastructureManager createInfrastructureManager(int infType){
 		if(infType == InfrastructureType.PHYSICAL_CLUSTER.ofType()) {
 			return new PhysicalClusterManager();
+		}
+		else if(infType == InfrastructureType.LOCAL_MULTITHREAD.ofType()){
+			return new ThreadNodeManager();
 		}
 		return null;
 	}

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/InfrastructureType.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/InfrastructureType.java
@@ -1,7 +1,7 @@
 package uk.ac.imperial.lsds.seepmaster.infrastructure.master;
 
 public enum InfrastructureType {
-	PHYSICAL_CLUSTER(0), YARN_CLUSTER(1), DOCKER_CLUSTER(2), VIRTUAL_CLUSTER(3), SHARED_PHYSICAL_CLUSTER(4);
+	PHYSICAL_CLUSTER(0), YARN_CLUSTER(1), LOCAL_MULTITHREAD(2), DOCKER_CLUSTER(3), VIRTUAL_CLUSTER(4), SHARED_PHYSICAL_CLUSTER(5);
 	
 	private int type;
 	

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/ThreadNode.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/ThreadNode.java
@@ -1,0 +1,49 @@
+package uk.ac.imperial.lsds.seepmaster.infrastructure.master;
+
+import java.net.InetAddress;
+
+import uk.ac.imperial.lsds.seep.infrastructure.EndPoint;
+import uk.ac.imperial.lsds.seep.infrastructure.ExecutionUnitType;
+import uk.ac.imperial.lsds.seep.util.Utils;
+
+public class ThreadNode implements ExecutionUnit {
+
+	private static final ExecutionUnitType executionUnitType = ExecutionUnitType.THREAD_NODE;
+	
+	private EndPoint ep;
+	private int id;
+
+	public ThreadNode(InetAddress ip, int port, int dataPort) {
+		this.id = Utils.computeIdFromIpAndPort(ip, port);
+		this.ep = new EndPoint(id, ip, port, dataPort);
+	}
+
+	@Override
+	public EndPoint getEndPoint() {
+		return ep;
+	}
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public ExecutionUnitType getType() {
+		return executionUnitType;
+	}
+	
+	@Override
+	public String toString(){
+		String ls = System.getProperty("line.separator");
+		StringBuilder sb = new StringBuilder();
+		sb.append("TYPE: "+executionUnitType.name());
+		sb.append(ls);
+		sb.append("IP: "+ep.getIp().toString());
+		sb.append(ls);
+		sb.append("PORT: "+ep.getPort());
+		sb.append(ls);
+		return sb.toString();
+	}
+
+}

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/ThreadNodeManager.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/infrastructure/master/ThreadNodeManager.java
@@ -1,0 +1,153 @@
+package uk.ac.imperial.lsds.seepmaster.infrastructure.master;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import joptsimple.OptionParser;
+import uk.ac.imperial.lsds.seep.comm.Connection;
+import uk.ac.imperial.lsds.seep.config.CommandLineArgs;
+import uk.ac.imperial.lsds.seep.config.ConfigKey;
+import uk.ac.imperial.lsds.seep.infrastructure.ExecutionUnitType;
+import uk.ac.imperial.lsds.seep.util.Utils;
+import uk.ac.imperial.lsds.seepworker.Main;
+import uk.ac.imperial.lsds.seepworker.WorkerConfig;
+import uk.ac.imperial.lsds.seepworker.WorkerThread;
+
+public class ThreadNodeManager implements InfrastructureManager {
+	
+	final private Logger LOG = LoggerFactory.getLogger(ThreadNodeManager.class);
+	public final ExecutionUnitType executionUnitType = ExecutionUnitType.THREAD_NODE;
+	private ExecutorService executorPool;
+	private Deque<ExecutionUnit> threadNodes;
+	private Map<Integer, Connection> connectionstoThreadNodes;
+	private int currDataPort = 4600;
+	private int currWorkerPort = 3600;
+
+	public ThreadNodeManager(){
+		this.threadNodes = new ArrayDeque<>();
+		this.connectionstoThreadNodes = new HashMap<>();
+	}
+	
+	@Override
+	public ExecutionUnit buildExecutionUnit(InetAddress ip, int port, int dataPort) {
+		return new ThreadNode(ip, port, dataPort);
+	}
+	
+	@Override
+	public void addExecutionUnit(ExecutionUnit eu) {
+		threadNodes.push(eu);
+		connectionstoThreadNodes.put(eu.getId(), new Connection(eu.getEndPoint()));
+	}
+	
+	@Override
+	public ExecutionUnit getExecutionUnit(){
+		LOG.debug("ExecutionUnit DEQUEUE: "+ threadNodes.peek());
+		
+		if(threadNodes.size() > 0){
+			LOG.debug("Returning 1 executionUnit, remaining: {}", threadNodes.size()-1);
+			return threadNodes.pop();
+		}
+		else{
+			LOG.error("No available executionUnits !!!");
+			return null;
+		}
+	}
+
+	@Override
+	public boolean removeExecutionUnit(int id) {
+		for(ExecutionUnit eu : threadNodes){
+			if(eu.getId() == id){
+				boolean success = threadNodes.remove(eu);
+				if(success){
+					LOG.info("ExecutionUnit id: {} was removed");
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public int executionUnitsAvailable() {
+		return threadNodes.size();
+	}
+
+	@Override
+	public void claimExecutionUnits(int numExecutionUnits) {
+		//Initialise the Worker threadPool
+		this.executorPool = Executors.newFixedThreadPool(numExecutionUnits);
+		
+		for(int i = numExecutionUnits; i > 0 ; i--){
+			//Need a more elegant way to get Master's configuration
+			HashMap<String,Object> map = new HashMap<>();
+			map.put("master.ip", "127.0.0.1");
+			map.put("master.port", "3500");
+			map.put("data.port", this.currDataPort);
+			map.put("worker.port", this.currWorkerPort);
+
+			
+			// Get default properties defined in the WorkerConfig file
+			List<ConfigKey> configKeys = WorkerConfig.getAllConfigKey();
+			OptionParser parser = new OptionParser();
+			CommandLineArgs cla = new CommandLineArgs(new String[0], parser, configKeys);
+			Properties commandLineProperties = cla.getProperties();
+	
+			// Custom thread properties
+			Properties fileProperties = new Properties();
+			fileProperties.putAll(map);
+	
+			Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(fileProperties,
+					commandLineProperties);
+			
+			WorkerConfig wc = new WorkerConfig(validatedProperties);
+			
+			Runnable threadWorker = new WorkerThread(wc);
+			this.executorPool.execute(threadWorker);
+			//this.addExecutionUnit( buildExecutionUnit(InetAddress.getLoopbackAddress(), currWorkerPort,  currDataPort));
+			
+			this.currDataPort+=100;
+			this.currWorkerPort+=100;
+		}
+	}
+
+	@Override
+	public void decommisionExecutionUnits(int numExecutionUnits) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void decommisionExecutionUnit(ExecutionUnit eu) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public Set<Connection> getConnectionsTo(Set<Integer> executionUnitIds) {
+		Set<Connection> cs = new HashSet<>();
+		for(Integer id : executionUnitIds) {
+			// TODO: check that the conn actually exists
+			cs.add(connectionstoThreadNodes.get(id));
+		}
+		return cs;
+	}
+
+	@Override
+	public Connection getConnectionTo(int executionUnitId) {
+		return connectionstoThreadNodes.get(executionUnitId);
+	}
+
+}

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
@@ -31,6 +31,7 @@ import uk.ac.imperial.lsds.seep.util.Utils;
 import uk.ac.imperial.lsds.seepmaster.LifecycleManager;
 import uk.ac.imperial.lsds.seepmaster.infrastructure.master.ExecutionUnit;
 import uk.ac.imperial.lsds.seepmaster.infrastructure.master.InfrastructureManager;
+import uk.ac.imperial.lsds.seepmaster.infrastructure.master.ThreadNodeManager;
 
 import com.esotericsoftware.kryo.Kryo;
 
@@ -101,6 +102,14 @@ public class QueryManager {
 		this.executionUnitsRequiredToStart = this.computeRequiredExecutionUnits(lsq);
 		LOG.info("New query requires: {} units to start execution", this.executionUnitsRequiredToStart);
 		lifeManager.tryTransitTo(LifecycleManager.AppStatus.QUERY_SUBMITTED);
+		/**
+		 * If  in MultiThread Mode - create the needed operator threads
+		 */
+		if(inf.getClass().equals(ThreadNodeManager.class)){
+			LOG.info("Local MultiThread Mode: Query needs ["+ lsq.getAllOperators().size() + "] Operators!");
+			inf.claimExecutionUnits(this.lsq.getAllOperators().size());
+			
+		}
 		return true;
 	}
 	
@@ -110,6 +119,7 @@ public class QueryManager {
 			LOG.error("Attempt to violate application lifecycle");
 			return false;
 		}
+
 		// Check whether there are sufficient execution units to deploy query
 		if(!canStartExecution()){
 			LOG.warn("Cannot deploy query, not enough nodes. Required: {}, available: {}"

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -44,7 +44,7 @@ public class Main {
 	
 	final private static Logger LOG = LoggerFactory.getLogger(Main.class);
 	
-	private void executeWorker(WorkerConfig wc){
+	public void executeWorker(WorkerConfig wc){
 		int masterPort = wc.getInt(WorkerConfig.MASTER_PORT);
 		InetAddress masterIp = null;
 		try {

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/WorkerThread.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/WorkerThread.java
@@ -1,0 +1,24 @@
+package uk.ac.imperial.lsds.seepworker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkerThread implements Runnable{
+	
+	final private static Logger LOG = LoggerFactory.getLogger(WorkerThread.class);
+	private WorkerConfig wc;
+	private Main workerInstance;
+	
+	public WorkerThread(WorkerConfig wc){
+		this.wc=wc;
+		this.workerInstance = new Main();
+	}
+	
+	@Override
+	public void run() {
+		
+		LOG.info("Starting Seep Worker as a Thread");
+		this.workerInstance.executeWorker(this.wc);
+
+	}
+}


### PR DESCRIPTION
- New deployment option implementation - Seep Multi-Thread. After loading query it startes the needed SeepWorkers in new threads without afftecting the existing query lifecycle
- Workers and Master now run on the same JVM
- Tested with properties file and also console input
- Can be used for bebuging purposes as well 
